### PR TITLE
GUI-001: Complete multi-line prompt box and handler tests (#2)

### DIFF
--- a/01_src/tinyllama/gui/app.py
+++ b/01_src/tinyllama/gui/app.py
@@ -1,0 +1,41 @@
+import json                   # Imports the json module for encoding and decoding JSON data
+import tkinter as tk          # Imports the tkinter library and aliases it as tk for GUI components
+from tkinter import ttk       # Imports themed tkinter widgets (ttk) for a modern look
+
+
+class TinyLlamaGUI(tk.Tk):    # Defines a new class TinyLlamaGUI, which inherits from Tkinter's main window class
+    """Desktop prompt window (GUI-001)."""
+
+    def __init__(self) -> None:           # Constructor method, initializes the GUI
+        super().__init__()                # Calls the parent (tk.Tk) constructor
+        self.title("TinyLlama Prompt")    # Sets the window title
+
+        # 5 rows × 80 cols prompt box
+        self.prompt_box = tk.Text(self, width=80, height=5, wrap="word")  # Creates a multi-line Text widget for prompt input
+        self.prompt_box.pack(padx=10, pady=10)                            # Adds the prompt box to the window with padding
+
+        # Ctrl+Enter == Send
+        self.prompt_box.bind("<Control-Return>", self._on_send_event)     # Binds Ctrl+Enter key event to the _on_send_event handler
+
+        self.send_btn = ttk.Button(self, text="Send", command=self._on_send)  # Creates a Send button that calls _on_send when clicked
+        self.send_btn.pack(padx=10, pady=5)                                   # Adds the Send button to the window with padding
+
+    # ————— helpers ————
+    @staticmethod
+    def build_payload(text: str) -> str:                  # Static method to build a JSON payload from the input text
+        """Return JSON string preserving newlines."""
+        return json.dumps({"prompt": text})               # Converts a dictionary with the prompt text into a JSON-formatted string
+
+    # ————— handlers ————
+    def _on_send_event(self, event):          # Event handler for Ctrl+Enter
+        self._on_send()                      # Calls the main send handler
+        return "break"                       # Prevents Tkinter from adding a newline on Ctrl+Enter
+
+    def _on_send(self):                      # Main send handler for both button click and Ctrl+Enter
+        text = self.prompt_box.get("1.0", tk.END).rstrip("\n")  # Retrieves all text from the prompt box, strips trailing newlines
+        payload = self.build_payload(text)                      # Builds a JSON payload from the entered text
+        print(payload)                                          # Prints the payload (for now, as a stub for sending to API)
+
+
+if __name__ == "__main__":           # Runs this code block only if the file is executed directly
+    TinyLlamaGUI().mainloop()        # Creates an instance of TinyLlamaGUI and starts the Tkinter event loop

--- a/01_src/tinyllama/gui/test_app.py
+++ b/01_src/tinyllama/gui/test_app.py
@@ -1,0 +1,19 @@
+import json
+from tinyllama.gui.app import TinyLlamaGUI
+from unittest.mock import MagicMock
+
+def test_build_payload_preserves_newlines():
+    gui = TinyLlamaGUI()
+    text = "line1\nline2\nline3"
+    payload = gui.build_payload(text)
+    assert json.loads(payload)["prompt"] == text
+
+def test_ctrl_enter_binding_exists():
+    gui = TinyLlamaGUI()
+    assert gui.prompt_box.bind("<Control-Return>")
+
+def test_on_send_event_calls_on_send():
+    gui = TinyLlamaGUI()
+    gui._on_send = MagicMock()         # Replace real handler with a mock
+    gui._on_send_event(event=None)     # Simulate event call
+    assert gui._on_send.called         # Check the handler was actually called


### PR DESCRIPTION
Implement GUI-001: Multi-line Prompt Box with Ctrl+Enter Send

This PR adds the core desktop GUI prompt box using Tkinter with the following features:

Multi-line Text widget sized 5 rows × 80 columns

Ctrl+Enter keybinding triggers the same send handler as the Send button

JSON payload builder preserving newlines

Basic unit tests verifying payload integrity and keybinding presence

Mock-based test confirming the send handler is called on Ctrl+Enter

This is a foundational step for the TinyLlama Desktop Client, enabling intuitive user input and future integration with inference backend.