### PR TITLE
GUI-003: Red Stop-GPU button triggers /stop, handles toast, and posts CloudWatch metric (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.pyd
 
 # Distribution / packaging
+.pytest_cache/
 .Python
 build/
 develop-eggs/

--- a/01_src/tinyllama/gui/app.py
+++ b/01_src/tinyllama/gui/app.py
@@ -1,46 +1,52 @@
-import json, threading, time
-import tkinter as tk
-from tkinter import ttk
+import json, threading, time, requests, tkinter as tk
+from tkinter import ttk, messagebox
 
 
 class TinyLlamaGUI(tk.Tk):
-    """Desktop prompt window (GUI-001 / GUI-002)."""
+    """Desktop GUI — GUI-001/002/003."""
 
     # ---------- ctor ----------
     def __init__(self) -> None:
         super().__init__()
         self.title("TinyLlama Prompt")
 
-        # prompt box: 5×80
+        # prompt
         self.prompt_box = tk.Text(self, width=80, height=5, wrap="word")
         self.prompt_box.pack(padx=10, pady=10)
 
-        # send button + spinner
+        # button frame
         btn_frame = ttk.Frame(self)
         btn_frame.pack(padx=10, pady=5, fill="x")
 
+        # Send button + spinner
         self.send_btn = ttk.Button(btn_frame, text="Send", command=self._on_send)
         self.send_btn.pack(side="left")
 
-        self.spinner = ttk.Progressbar(
-            btn_frame, mode="indeterminate", length=120
-        )                                            # initially hidden
+        self.spinner = ttk.Progressbar(btn_frame, mode="indeterminate", length=120)
 
-        # Ctrl+Enter == send
+        # NEW: Stop-GPU button
+        self.stop_btn = tk.Button(
+            btn_frame,
+            text="Stop GPU",
+            bg="#d9534f",
+            fg="white",
+            command=self._on_stop_gpu,
+        )
+        self.stop_btn.pack(side="right", padx=(10, 0))
+
+        # keybinding
         self.prompt_box.bind("<Control-Return>", self._on_send_event)
 
     # ---------- helpers ----------
     @staticmethod
     def build_payload(text: str) -> str:
-        """Return JSON string preserving newlines."""
         return json.dumps({"prompt": text})
 
     def _set_busy(self, busy: bool) -> None:
-        """Enable/disable send button & toggle spinner."""
         if busy:
             self.send_btn.state(["disabled"])
             self.spinner.pack(side="left", padx=10)
-            self.spinner.start(10)                  # 10 ms per step
+            self.spinner.start(10)
         else:
             self.spinner.stop()
             self.spinner.pack_forget()
@@ -52,23 +58,32 @@ class TinyLlamaGUI(tk.Tk):
         return "break"
 
     def _on_send(self):
-        """Read prompt, disable UI, call API thread, re-enable on done."""
         text = self.prompt_box.get("1.0", tk.END).rstrip("\n")
         payload = self.build_payload(text)
         self._set_busy(True)
+        threading.Thread(target=self._send_to_api, args=(payload,), daemon=True).start()
 
-        # simulate (or later: real) API call in background thread
-        threading.Thread(
-            target=self._send_to_api, args=(payload,), daemon=True
-        ).start()
+    def _on_stop_gpu(self):
+        self.stop_btn.config(state="disabled")
+        threading.Thread(target=self._stop_gpu_api, daemon=True).start()
 
     # ---------- backend ----------
     def _send_to_api(self, payload: str) -> None:
-        """Stub that blocks 2 s then prints payload (simulate inference)."""
-        time.sleep(2)                               # 2-s artificial delay
+        time.sleep(2)                      # stub
         print(payload)
-        # after thread completes, re-enable UI in main thread
-        self.after(10, lambda: self._set_busy(False))
+        self.after(0, lambda: self._set_busy(False))
+
+    def _stop_gpu_api(self) -> None:
+        """POST /stop and handle toast + metrics."""
+        try:
+            r = requests.post("http://localhost:8000/stop", timeout=8)
+            r.raise_for_status()
+            print("CloudWatch: ManualStops +1")      # stub metric
+            self.after(0, lambda: messagebox.showinfo("GPU", "GPU stopped."))
+        except Exception as exc:
+            self.after(0, lambda exc=exc: messagebox.showerror("GPU", f"Stop failed: {exc}"))
+        finally:
+            self.after(0, lambda: self.stop_btn.config(state="normal"))
 
 
 if __name__ == "__main__":

--- a/02_tests/gui/test_stop_gpu.py
+++ b/02_tests/gui/test_stop_gpu.py
@@ -1,0 +1,65 @@
+import types
+import pytest
+from unittest.mock import patch
+from tinyllama.gui.app import TinyLlamaGUI
+import tinyllama.gui.app as app_mod
+
+@pytest.fixture
+def gui():
+    g = TinyLlamaGUI()
+    g.withdraw()
+    yield g
+    g.destroy()
+
+def test_stop_button_properties(gui):
+    assert gui.stop_btn["text"] == "Stop GPU"
+    assert gui.stop_btn["bg"] == "#d9534f"
+
+def test_stop_gpu_success_toast_and_metric(gui, monkeypatch):
+    # Patch threading.Thread to run target synchronously
+    monkeypatch.setattr(
+        app_mod.threading, "Thread",
+        lambda target, args=(), daemon=None:
+            types.SimpleNamespace(start=lambda: target(*args))
+    )
+    # Mock HTTP POST /stop as 200 OK
+    monkeypatch.setattr(
+        "requests.post",
+        lambda *a, **k: types.SimpleNamespace(status_code=200, raise_for_status=lambda: None)
+    )
+    # Spy on toast
+    called = {"info": False}
+    monkeypatch.setattr(
+        "tkinter.messagebox.showinfo",
+        lambda *a, **k: called.__setitem__("info", True)
+    )
+
+    gui._on_stop_gpu()
+    gui.update()
+    assert called["info"] is True
+    assert gui.stop_btn["state"] == "normal"
+
+def test_stop_gpu_failure_shows_error(gui, monkeypatch):
+    # Patch threading.Thread to run target synchronously
+    monkeypatch.setattr(
+        app_mod.threading, "Thread",
+        lambda target, args=(), daemon=None:
+            types.SimpleNamespace(start=lambda: target(*args))
+    )
+    # Mock HTTP POST /stop to raise an error
+    monkeypatch.setattr(
+        "requests.post",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("net down"))
+    )
+    # Spy on toast
+    called = {"err": False}
+    monkeypatch.setattr(
+        "tkinter.messagebox.showerror",
+        lambda *a, **k: called.__setitem__("err", True)
+    )
+
+    gui._on_stop_gpu()
+    gui.update()
+    assert called["err"] is True
+    assert gui.stop_btn["state"] == "normal"
+


### PR DESCRIPTION
Implements GUI-003 from Epic 1.

Adds a red “Stop GPU” button (#d9534f, white text) to the desktop GUI.

Button sends a POST request to /stop when clicked.

Displays a toast (info message) on success, error message on failure.

Button is disabled during the request, re-enabled after completion.

Stubbed CloudWatch “ManualStops” metric increment is printed on success.

All stop-GPU logic is handled in a background thread for UI responsiveness.

Unit tests mock the API and ensure correct UI/UX and error handling; tests patched to be deterministic for CI/headless runs.

Test file relocated, threading bugs fixed, and error dialog lambda properly scoped.

Closes #4.