### PR TITLE
API-001: FastAPI skeleton, red-gate test, CI, and CODEOWNERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: API CI
+
+on:
+  push:
+    paths:
+      - "api/**"
+      - "tests/**"
+      - ".github/workflows/ci.yml"
+      - "requirements.txt"
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Pytest (expecting failure)
+        run: |
+          pytest -q
+        continue-on-error: false  # pipeline must go red

--- a/02_tests/api/test_placeholder.py
+++ b/02_tests/api/test_placeholder.py
@@ -1,0 +1,8 @@
+"""
+Deliberately failing placeholder to lock the pipeline red
+until real behaviour is implemented in later stories.
+"""
+
+def test_api_placeholder_fails():
+    # remove this assert when first real route test is added
+    assert False, "API skeleton: replace with real tests in API-002+"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/api/*          @RusbehAbtahi
+/02_tests/api/* @RusbehAbtahi

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,8 @@
+# TinyLlama Edge API — Skeleton
+
+## Quick local run
+
+```bash
+# inside repo root
+pip install -r requirements.txt
+uvicorn api.routes:app --reload --port 8000

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,8 @@
+openapi: 3.1.0
+info:
+  title: TinyLlama Edge API
+  version: 0.0.0-draft
+  description: |
+    **Skeleton only.** Paths will be filled in API-002+
+paths: {}
+components: {}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+pytest==8.2.0

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,0 +1,20 @@
+"""
+api.routes
+==========
+
+Empty FastAPI app placeholder.  Real routes land in API-002+.
+"""
+
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="TinyLlama Edge API",
+    version="0.0.0-draft",
+    description="🚧  Skeleton only—routes land in API-002+",
+    docs_url="/docs", redoc_url="/redoc",
+)
+
+# keep file non-empty or FastAPI will raise at start-up
+@app.get("/__placeholder__", include_in_schema=False)
+async def _placeholder():
+    return {"status": "placeholder"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = 02_tests/gui
+testpaths = 02_tests
 pythonpath = 01_src
 addopts   = -ra


### PR DESCRIPTION
**API-001: FastAPI Skeleton, Red-Gate Test, and CI**

This PR introduces the foundational API skeleton for the TinyLlama Edge API project:

* Sets up a minimal FastAPI server (`api/routes.py`) with placeholder route
* Adds an OpenAPI YAML contract stub
* Implements a deliberately failing test (`test_placeholder.py`) to enforce TDD (“red-gate”)
* Adds a GitHub Actions workflow for automatic CI on every push/PR
* Adds a `CODEOWNERS` file for review ownership
* Updates dependencies and test discovery (`pytest.ini`)

> Note: CI is expected to fail (red-gate is intentional).
> Ready for real endpoint implementation in API-002.

